### PR TITLE
Configurable file paths via CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "camino",
  "hyper",
  "kittycad",
+ "pico-args",
  "serde",
  "serde_json",
  "serde_yaml 0.9.21",
@@ -1236,6 +1237,12 @@ dependencies = [
  "serde_derive",
  "thiserror",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1.4.0"
 camino = { version = "1.1.4", features = ["serde1"] }
 hyper = { version = "0.14.26", features = ["server"] }
 kittycad = "0.2.10"
+pico-args = "0.5.0"
 serde = "1.0.164"
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Just use `cargo run`.
 
 You can edit the probes themselves in `configuration/probes.yaml`, or the overall configuration in `configuration/config.yaml`.
 
+To use a different path, set the desired path with `--config-file` or `--probes-file`.
+
 ## Testing
 
 Just use `cargo test`.

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -1,0 +1,4 @@
+period: { secs: 60, nanos: 0 }
+user_agent: kc-apimon
+metrics_addr: 0.0.0.0:8001
+log_json: false

--- a/cfg/probes.yaml
+++ b/cfg/probes.yaml
@@ -1,0 +1,11 @@
+- name: mass_of_cube
+  endpoint: !FileMass # this is called "!tag" syntax
+    file_path: testdata/cube.obj
+    src_format: obj
+    material_density: 1.0
+    expected:
+      mass: 1.0
+      src_format: obj
+      status: Completed
+- name: ping
+  endpoint: !Ping

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,31 @@
+use camino::Utf8PathBuf;
+
+#[derive(Debug)]
+pub struct AppArgs {
+    pub config_file: Utf8PathBuf,
+    pub probes_file: Utf8PathBuf,
+}
+
+const HELP: &str = r#"Tests uptime of KittyCAD API.
+Usage: apimon [--config-file <path>] [--probe-file <path>]"#;
+
+pub fn parse_args() -> Result<AppArgs, pico_args::Error> {
+    let mut pargs = pico_args::Arguments::from_env();
+
+    // Help has a higher priority and should be handled separately.
+    if pargs.contains(["-h", "--help"]) {
+        print!("{}", HELP);
+        std::process::exit(0);
+    }
+
+    let args = AppArgs {
+        config_file: pargs
+            .opt_value_from_str("--config-file")?
+            .unwrap_or("configuration/config.yaml".into()),
+        probes_file: pargs
+            .opt_value_from_str("--probes-file")?
+            .unwrap_or("configuration/probes.yaml".into()),
+    };
+
+    Ok(args)
+}


### PR DESCRIPTION
I figure this will make the program easier to deploy. E.g. you might want to have separate config files for prod and staging. Now you can pass whichever file you want to the program instead of being stuck with configuration/probes.yaml