### PR TITLE
Validate that base_url is a URL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use reqwest::Url;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -7,7 +8,7 @@ pub struct Config {
     pub period: Duration,
     pub user_agent: String,
     pub metrics_addr: std::net::SocketAddr,
-    pub base_url: Option<String>,
+    pub base_url: Option<Url>,
     pub log_json: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn make_client(config: &Config, api_token: String) -> kittycad::Client {
     let websocket = base_client().http1_only();
     let mut client = kittycad::Client::new_from_reqwest(api_token, http, websocket);
     if let Some(ref url) = config.base_url {
-        client.set_base_url(url);
+        client.set_base_url(url.to_string());
     }
     client
 }


### PR DESCRIPTION
This way, if you put an invalid URL like "localhost:8080" (which is missing http://) you get the error message when you run the program, not when the probe fails. 